### PR TITLE
Update MOPAC from 2012 to 2016

### DIFF
--- a/mopac/bld.bat
+++ b/mopac/bld.bat
@@ -4,5 +4,5 @@ xcopy /s %SRC_DIR% %PREFIX%\Scripts
 mkdir %PREFIX%\bin
 
 (echo set MOPAC_LICENSE=%PREFIX%\Scripts) >> %PREFIX%\Scripts\mopac.bat
-(echo %PREFIX%\Scripts\MOPAC2012.exe %%1) >> %PREFIX%\Scripts\mopac.bat
+(echo %PREFIX%\Scripts\MOPAC2016.exe %%1) >> %PREFIX%\Scripts\mopac.bat
 chmod +x %PREFIX%\Scripts\mopac.bat

--- a/mopac/build.sh
+++ b/mopac/build.sh
@@ -3,7 +3,7 @@ mkdir -p $PREFIX/opt/mopac
 cp -R $SRC_DIR/* $PREFIX/opt/mopac/
 chmod +x $PREFIX/opt/mopac/MOPAC2016.exe
 
-mkdir $PREFIX/bin
+mkdir -p $PREFIX/bin
 cp $RECIPE_DIR/mopac.sh $PREFIX/bin/mopac
 chmod +x $PREFIX/bin/mopac
 

--- a/mopac/build.sh
+++ b/mopac/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 mkdir -p $PREFIX/opt/mopac
 cp -R $SRC_DIR/* $PREFIX/opt/mopac/
-chmod +x $PREFIX/opt/mopac/MOPAC2012.exe
+chmod +x $PREFIX/opt/mopac/MOPAC2016.exe
 
 mkdir $PREFIX/bin
 cp $RECIPE_DIR/mopac.sh $PREFIX/bin/mopac

--- a/mopac/meta.yaml
+++ b/mopac/meta.yaml
@@ -1,28 +1,29 @@
 package:
   name: mopac
-  version: 2012
+  version: 2016
 
 source:
-  fn: MOPAC2012_for_Macintosh.zip # [osx]
-  url: http://openmopac.net/MOPAC2012_for_Macintosh.zip # [osx]
-  md5: 2bd2f292f08f05a4ef9f9f9a45bc0df4 # [osx]
+  fn: MOPAC2016_for_Macintosh.zip # [osx]
+  url: http://openmopac.net/MOPAC2016_for_Macintosh.zip # [osx]
+  md5: 40adbeaccd02d0980a6dc29a5e0d74f2 # [osx]
   
-  fn: MOPAC2012_for_Linux_64_bit.zip # [linux64]
-  url: http://openmopac.net/MOPAC2012_for_Linux_64_bit.zip # [linux64]
-  md5: d5909a8cee3f8d4b174a728611226861 # [linux64]
+  
+  fn: MOPAC2016_for_Linux_64_bit.zip # [linux64]
+  url: http://openmopac.net/MOPAC2016_for_Linux_64_bit.zip # [linux64]
+  md5: 3068aee46894f625b6baf5eab5b1c2e8 # [linux64]
 
-  fn: MOPAC2012_for_Linux_32_bit.zip # [linux32]
-  url: http://openmopac.net/MOPAC2012_for_Linux_32_bit.zip # [linux32]
-  md5: 15273d86b86d2e4cbbb5e493340d881d # [linux32]
+  fn: MOPAC2016_for_Linux_32_bit.zip # [linux32]
+  url: http://openmopac.net/MOPAC2016_for_Linux_32_bit.zip # [linux32]
+  md5: ca976f298d5984c2f2b04a8955eadf28 # [linux32]
   
-  fn: MOPAC2012_standalone_for_WINDOWS_64_bit.zip [win64]
-  url:  http://openmopac.net/MOPAC2012_standalone_for_WINDOWS_64_bit.zip [win64]
+  fn: MOPAC2016_standalone_for_WINDOWS_64_bit.zip [win64]
+  url:  http://openmopac.net/MOPAC2016_standalone_for_WINDOWS_64_bit.zip [win64]
   
-  fn: MOPAC2012_standalone_for_WINDOWS_32_bit.zip [win32]
-  url: http://openmopac.net/MOPAC2012_standalone_for_WINDOWS_32_bit.zip [win32]
+  fn: MOPAC2016_standalone_for_WINDOWS_32_bit.zip [win32]
+  url: http://openmopac.net/MOPAC2016_standalone_for_WINDOWS_32_bit.zip [win32]
   
 build:
-  number: 2
+  number: 1
   binary_relocation: false
 
 test:

--- a/mopac/meta.yaml
+++ b/mopac/meta.yaml
@@ -10,7 +10,7 @@ source:
   
   fn: MOPAC2016_for_Linux_64_bit.zip # [linux64]
   url: http://openmopac.net/MOPAC2016_for_Linux_64_bit.zip # [linux64]
-  md5: 3068aee46894f625b6baf5eab5b1c2e8 # [linux64]
+  md5: 83ddd4a87760bc6f793237923b69e935 # [linux64]
 
   fn: MOPAC2016_for_Linux_32_bit.zip # [linux32]
   url: http://openmopac.net/MOPAC2016_for_Linux_32_bit.zip # [linux32]

--- a/mopac/mopac.sh
+++ b/mopac/mopac.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-# A wrapper to set up the environment and call MOPAC2012.exe
-MOPAC_LICENSE=/opt/anaconda1anaconda2anaconda3/opt/mopac/ LD_LIBRARY_PATH=/opt/anaconda1anaconda2anaconda3/opt/mopac/ /opt/anaconda1anaconda2anaconda3/opt/mopac/MOPAC2012.exe "$@"
+# A wrapper to set up the environment and call MOPAC2016.exe
+MOPAC_LICENSE=/opt/anaconda1anaconda2anaconda3/opt/mopac/ LD_LIBRARY_PATH=/opt/anaconda1anaconda2anaconda3/opt/mopac/ /opt/anaconda1anaconda2anaconda3/opt/mopac/MOPAC2016.exe "$@"


### PR DESCRIPTION
See https://github.com/ReactionMechanismGenerator/RMG-Py/issues/695
This updated recipe seems to work for me on my mac, and I have pushed the resulting binary to https://anaconda.org/rmg/mopac.  I haven't been able to test any of the other platforms, although I did my best to update them all.
