### PR TITLE
Add cclib 1.5.3

### DIFF
--- a/cclib/build.sh
+++ b/cclib/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+$PYTHON setup.py build
+$PYTHON setup.py install
+
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/cclib/meta.yaml
+++ b/cclib/meta.yaml
@@ -1,0 +1,33 @@
+# This file created by conda-build 2.1.13
+#
+# This file, and the associated build.sh file do
+# not appear to work on later versions of
+# conda-build
+# ------------------------------------------------
+
+package:
+    name: cclib
+    version: '1.5.3'
+source:
+    git_url: https://github.com/cclib/cclib.git
+
+requirements:
+    build:
+        - python
+    run:
+        - python
+        - numpy
+test:
+    imports:
+        - cclib
+        - cclib.io
+        - cclib.bridge
+        - cclib.method
+        - cclib.parser
+        - cclib.progress
+about:
+    home: http://cclib.github.io/
+    license: GNU Library or Lesser General Public License (LGPL)
+    summary: 'cclib: parsers and algorithms for computational chemistry'
+extra:
+    final: true


### PR DESCRIPTION
Works for AutoTST but might not work for RMG without the modifications
that are in external/cclib in RMG.

The Conda recipe also appears to only work with conda-build version 2.1.13 or earlier.